### PR TITLE
Configure flutter_launcher_icons for app icon

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -22,6 +22,7 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
+  flutter_launcher_icons: ^0.14.4
 
 dependency_overrides:
   carousel_slider: ^4.2.0
@@ -41,3 +42,12 @@ flutter:
     - assets/images/zambia_lusaka.png
     - assets/images/burundi_bujumbura.png
     - assets/images/app_icon.png
+
+flutter_icons:
+  android: true
+  ios: true
+  linux: true
+  macos: true
+  web: true
+  windows: true
+  image_path: assets/images/app_icon.png


### PR DESCRIPTION
## Summary
- add flutter_launcher_icons dev dependency
- configure icon generation for all supported platforms using `assets/images/app_icon.png`

## Testing
- `flutter pub get` *(fails: `flutter: command not found`)*
- `flutter pub run flutter_launcher_icons:main` *(fails: `flutter: command not found`)*
- `flutter test` *(fails: `flutter: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684a568a06a0832a92fcba4f6394b99a