### PR TITLE
Remove underline from contact phone numbers

### DIFF
--- a/lib/contact_page.dart
+++ b/lib/contact_page.dart
@@ -163,7 +163,7 @@ class ContactLocationsPage extends StatelessWidget {
                         style: const TextStyle(
                           color: Colors.white70,
                           fontSize: 16,
-                          decoration: TextDecoration.underline,
+                          decoration: TextDecoration.none,
                         ),
                       ),
                     ),


### PR DESCRIPTION
## Summary
- show phone links without underline on the contact page

## Testing
- `flutter format lib/contact_page.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684be8ee09f8832a8d214e867237c510