### PR TITLE
Implement live luggage tracking

### DIFF
--- a/lib/tracking_result_page.dart
+++ b/lib/tracking_result_page.dart
@@ -1,0 +1,56 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import 'localization.dart';
+import 'providers/language_provider.dart';
+
+class TrackingResultPage extends StatelessWidget {
+  final Map<String, String> info;
+  const TrackingResultPage({super.key, required this.info});
+
+  Widget _buildRow(BuildContext context, String label, String value) {
+    final theme = Theme.of(context);
+    return Container(
+      padding: const EdgeInsets.symmetric(vertical: 12, horizontal: 16),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        children: [
+          Text(label,
+              style:
+                  theme.textTheme.bodyMedium?.copyWith(fontWeight: FontWeight.bold)),
+          Flexible(
+            child: Text(
+              value,
+              style: theme.textTheme.bodyMedium,
+              textAlign: TextAlign.right,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final loc =
+        AppLocalizations(Provider.of<LanguageProvider>(context).languageCode);
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(loc.translate('cargo_details')),
+      ),
+      body: ListView(
+        children: [
+          _buildRow(context, loc.translate('status'), info['Status'] ?? ''),
+          _buildRow(
+              context,
+              loc.translate('sender'),
+              '${info["Sender's name"] ?? ''} - ${info["Sender's phone number"] ?? ''}'),
+          _buildRow(
+              context,
+              loc.translate('receiver'),
+              '${info["Receiver's name"] ?? ''} - ${info["Receiver's phone number"] ?? ''}'),
+        ],
+      ),
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,6 +16,8 @@ dependencies:
   provider: ^6.1.0
   share_plus: ^11.0.0
   url_launcher: ^6.2.1
+  http: ^0.13.6
+  html: ^0.15.4
 
 
 


### PR DESCRIPTION
## Summary
- add `http` and `html` packages
- implement `_fetchTrackingData` to call live API and parse HTML
- show loading indicator while fetching and display parsed results
- introduce `TrackingResultPage` for the fetched data

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850126c75f8832ab57d917664aac4b8