### PR TITLE
Improve status colors and history page

### DIFF
--- a/lib/cargo_details_page.dart
+++ b/lib/cargo_details_page.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import 'status_utils.dart';
 
 import 'localization.dart';
 import 'providers/language_provider.dart';
@@ -12,8 +13,9 @@ class CargoDetailsPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final bool isOut = cargo['status'] == 'Out';
-    final Color baseColor = isOut ? Colors.red : Colors.blue;
+    final status = cargo['status']?.toString();
+    final bool isArrived = cargoArrived(status);
+    final Color baseColor = statusColor(status);
     final bool isDark = theme.brightness == Brightness.dark;
     final loc = AppLocalizations(Provider.of<LanguageProvider>(context).languageCode);
     final Map<String, dynamic>? dispatchInfo = cargo['dispatchInfo'];
@@ -110,7 +112,7 @@ class CargoDetailsPage extends StatelessWidget {
                     ],
                   ),
                   child: Text(
-                    loc.translate(isOut ? 'out' : 'store'),
+                    loc.translate(isArrived ? 'out' : 'store'),
                     style: const TextStyle(
                       color: Colors.white,
                       fontWeight: FontWeight.bold,

--- a/lib/enhanced_history_page.dart
+++ b/lib/enhanced_history_page.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:http/http.dart' as http;
 import 'package:provider/provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'status_utils.dart';
 
 import 'localization.dart';
 import 'providers/language_provider.dart';
@@ -181,16 +182,17 @@ class _EnhancedHistoryPageState extends State<EnhancedHistoryPage> {
           if (snapshot.connectionState != ConnectionState.done) {
             return const Center(child: CircularProgressIndicator());
           }
-          if (!snapshot.hasData || snapshot.data == null) {
-            return const SizedBox.shrink();
+          if (!snapshot.hasData || snapshot.data == null ||
+              (snapshot.data?.isEmpty ?? true)) {
+            return Center(child: Text(loc.translate('no_cargo_found')));
           }
           final historyItems = snapshot.data!;
           return ListView.builder(
             itemCount: historyItems.length,
             itemBuilder: (context, index) {
-              final status = historyItems[index]['status'];
-              final isOut = status == 'Out';
-              final baseColor = isOut ? Colors.red : Colors.blue;
+              final status = historyItems[index]['status']?.toString();
+              final isArrived = cargoArrived(status);
+              final baseColor = statusColor(status);
 
               return Card(
                 margin: const EdgeInsets.symmetric(vertical: 12.0, horizontal: 16.0),
@@ -243,7 +245,7 @@ class _EnhancedHistoryPageState extends State<EnhancedHistoryPage> {
                                   ],
                                 ),
                               ),
-                              if (isOut)
+                              if (isArrived)
                                 ExpansionTile(
                                   title: Text(
                                     loc.translate('dispatch_info'),
@@ -334,7 +336,7 @@ class _EnhancedHistoryPageState extends State<EnhancedHistoryPage> {
                           ],
                         ),
                         child: Text(
-                          loc.translate(isOut ? 'out' : 'store'),
+                          loc.translate(isArrived ? 'out' : 'store'),
                           style: const TextStyle(
                             color: Colors.white,
                             fontWeight: FontWeight.bold,

--- a/lib/status_utils.dart
+++ b/lib/status_utils.dart
@@ -1,0 +1,16 @@
+import 'package:flutter/material.dart';
+
+/// Determines if a cargo has arrived based on the status string.
+/// Currently checks for common keywords like "arrived", "delivered" or "out".
+bool cargoArrived(String? status) {
+  if (status == null) return false;
+  final lower = status.toLowerCase();
+  return lower.contains('arrived') ||
+      lower.contains('delivered') ||
+      lower.contains('out');
+}
+
+/// Returns the color to use for a cargo based on arrival status.
+Color statusColor(String? status) {
+  return cargoArrived(status) ? Colors.red : Colors.blue;
+}


### PR DESCRIPTION
## Summary
- color deliveries red if arrived using keyword checks
- share status color logic
- show a message on the history page if no data is returned

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68503d3b1608832a87719e65e8e632d1