### PR TITLE
Fix history API endpoint

### DIFF
--- a/lib/enhanced_history_page.dart
+++ b/lib/enhanced_history_page.dart
@@ -42,10 +42,9 @@ class _EnhancedHistoryPageState extends State<EnhancedHistoryPage> {
   }
 
   Future<List<Map<String, dynamic>>?> _fetchHistoryData(String phone) async {
-    final url =
-        Uri.parse('http://217.29.139.44:555/track/history.php?phone=$phone');
+    final url = Uri.parse('http://217.29.139.44:555/track/data.php');
     try {
-      final response = await http.get(url);
+      final response = await http.post(url, body: {'phone_no': phone});
       if (response.statusCode != 200) return null;
       return List<Map<String, dynamic>>.from(
           json.decode(response.body) as List<dynamic>);


### PR DESCRIPTION
## Summary
- point history page to the new endpoint `data.php`

## Testing
- `flutter test test/widget_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685044100d50832a821148439da2ab23