### PR TITLE
Update history page display

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,6 +18,7 @@ dependencies:
   url_launcher: ^6.2.1
   http: ^0.13.6
   html: ^0.15.4
+  intl: ^0.20.2
 
 
 


### PR DESCRIPTION
## Summary
- sort history by date and parse several formats
- show dispatch status, cargo status, and pricing info
- add date parsing utility
- include intl package for date parsing

## Testing
- `flutter pub get` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850cea45590832ab7022265ba0efcdd