### PR TITLE
Fix history page map syntax

### DIFF
--- a/lib/enhanced_history_page.dart
+++ b/lib/enhanced_history_page.dart
@@ -130,7 +130,8 @@ class _EnhancedHistoryPageState extends State<EnhancedHistoryPage> {
         'paidPrice': _first(['Paid price', 'Paid Price']),
         'toBePaidPrice':
             _first(['To be paid Price', 'To be paid price', 'To Be Paid Price']),
-      'totalPrice': _first(['Total price', 'Total Price']),
+        'totalPrice': _first(['Total price', 'Total Price']),
+      },
     };
   }
 


### PR DESCRIPTION
## Summary
- correct map closing brace in `EnhancedHistoryPage`

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850d43739cc832abc8819a344d0c736