### PR TITLE
Print API response when searching

### DIFF
--- a/lib/track_page.dart
+++ b/lib/track_page.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/foundation.dart';
 import 'package:http/http.dart' as http;
 import 'package:html/parser.dart' as html_parser;
 import 'package:provider/provider.dart';
@@ -44,6 +45,8 @@ class _TrackPageState extends State<TrackPage> {
         Uri.parse('http://217.29.139.44:555/track/ticket_info.php?code=$code');
     try {
       final response = await http.get(url);
+      // Print the raw API response so it can be copied from the console
+      debugPrint('API response: ${response.body}');
       if (response.statusCode != 200) return null;
       final document = html_parser.parse(response.body);
       final Map<String, String> result = {};


### PR DESCRIPTION
## Summary
- log the raw API response whenever cargo tracking is executed

## Testing
- `flutter test -r expanded` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68516110e624832ab4cdcdef9b365c87