### PR TITLE
Show all tracking details

### DIFF
--- a/lib/cargo_details_page.dart
+++ b/lib/cargo_details_page.dart
@@ -17,6 +17,8 @@ class CargoDetailsPage extends StatelessWidget {
     final bool isDispatched = cargo['dispatchInfo'] != null;
     final Map<String, dynamic>? dispatchInfo = cargo['dispatchInfo'];
     final Map<String, dynamic> cargoInfo = cargo['cargoInfo'];
+    final Map<String, dynamic> allDetails =
+        (cargo['allDetails'] as Map<String, dynamic>?) ?? {};
 
     final Color primaryColor = isDispatched ? Colors.red[600]! : Colors.blue[600]!;
 
@@ -136,6 +138,14 @@ class CargoDetailsPage extends StatelessWidget {
           buildRow(loc.translate('quantity'), cargoInfo['quantity'], alt: true),
           buildRow(loc.translate('payment_option'), cargoInfo['paymentOption']),
           buildRow(loc.translate('total_price'), cargoInfo['totalPrice'] ?? '-', alt: true),
+
+          if (allDetails.isNotEmpty) ...[
+            const Divider(thickness: 1),
+            ...List<Widget>.generate(allDetails.length, (index) {
+              final entry = allDetails.entries.elementAt(index);
+              return buildRow(entry.key, entry.value.toString(), alt: index.isOdd);
+            }),
+          ],
 
           const SizedBox(height: 24),
         ],

--- a/lib/track_page.dart
+++ b/lib/track_page.dart
@@ -101,6 +101,7 @@ class _TrackPageState extends State<TrackPage> {
       if (dispatchDate.isNotEmpty || dispatchStatus.isNotEmpty)
         'dispatchInfo': {'date': dispatchDate, 'status': dispatchStatus},
       'cargoInfo': cargoInfo,
+      'allDetails': info,
     };
   }
 


### PR DESCRIPTION
## Summary
- expose entire response map from `_convertToCargo`
- show additional backend details on CargoDetailsPage

## Testing
- `flutter test` *(fails: `flutter` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851c0aa9078832aad798cca3e188f4a