### PR TITLE
Refactor API base URL

### DIFF
--- a/lib/config.dart
+++ b/lib/config.dart
@@ -1,0 +1,6 @@
+class AppConfig {
+  static const String apiBaseUrl = String.fromEnvironment(
+    'API_BASE_URL',
+    defaultValue: 'http://217.29.139.44:555/',
+  );
+}

--- a/lib/enhanced_history_page.dart
+++ b/lib/enhanced_history_page.dart
@@ -7,6 +7,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 
 import 'localization.dart';
 import 'providers/language_provider.dart';
+import 'config.dart';
 
 /// Displays a list of previously tracked shipments fetched from the backend
 /// service using the receiver's phone number.
@@ -43,7 +44,7 @@ class _EnhancedHistoryPageState extends State<EnhancedHistoryPage> {
   }
 
   Future<List<Map<String, dynamic>>?> _fetchHistoryData(String phone) async {
-    final url = Uri.parse('http://217.29.139.44:555/track/data.php');
+    final url = Uri.parse('${AppConfig.apiBaseUrl}track/data.php');
     try {
       final response = await http.post(url, headers: {
         'Content-Type': 'application/x-www-form-urlencoded'

--- a/lib/track_page.dart
+++ b/lib/track_page.dart
@@ -8,6 +8,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 import 'cargo_details_page.dart';
 import 'providers/language_provider.dart';
 import 'localization.dart';
+import 'config.dart';
 
 class TrackPage extends StatefulWidget {
   const TrackPage({super.key});
@@ -42,7 +43,7 @@ class _TrackPageState extends State<TrackPage> {
   /// extracted values keyed by their labels.
   Future<Map<String, String>?> _fetchTrackingData(String code) async {
     final url =
-        Uri.parse('http://217.29.139.44:555/track/ticket_info.php?code=$code');
+        Uri.parse('${AppConfig.apiBaseUrl}track/ticket_info.php?code=$code');
     try {
       final response = await http.get(url);
       // Print the raw API response so it can be copied from the console


### PR DESCRIPTION
## Summary
- read API base URL from `AppConfig`
- update track and history pages to use configuration

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852622c5ab0832a983fd6271b7e43e8