### PR TITLE
Add widget tests for tracking and history pages

### DIFF
--- a/test/history_page_test.dart
+++ b/test/history_page_test.dart
@@ -1,0 +1,31 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+
+import 'package:sr_classic_transport/enhanced_history_page.dart';
+import 'package:sr_classic_transport/providers/theme_provider.dart';
+import 'package:sr_classic_transport/providers/language_provider.dart';
+import 'package:sr_classic_transport/localization.dart';
+
+void main() {
+  testWidgets('HistoryPage displays validation error when phone is empty', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      MultiProvider(
+        providers: [
+          ChangeNotifierProvider(create: (_) => ThemeProvider()),
+          ChangeNotifierProvider(create: (_) => LanguageProvider()),
+        ],
+        child: const MaterialApp(home: EnhancedHistoryPage()),
+      ),
+    );
+
+    await tester.pumpAndSettle();
+
+    final quickCheck = AppLocalizations('en').translate('quick_check');
+    await tester.tap(find.text(quickCheck));
+    await tester.pump();
+
+    final phoneError = AppLocalizations('en').translate('please_enter_phone_number');
+    expect(find.text(phoneError), findsOneWidget);
+  });
+}

--- a/test/track_page_test.dart
+++ b/test/track_page_test.dart
@@ -1,0 +1,34 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+
+import 'package:sr_classic_transport/track_page.dart';
+import 'package:sr_classic_transport/providers/theme_provider.dart';
+import 'package:sr_classic_transport/providers/language_provider.dart';
+import 'package:sr_classic_transport/localization.dart';
+
+void main() {
+  testWidgets('TrackPage displays validation errors when fields are empty', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      MultiProvider(
+        providers: [
+          ChangeNotifierProvider(create: (_) => ThemeProvider()),
+          ChangeNotifierProvider(create: (_) => LanguageProvider()),
+        ],
+        child: const MaterialApp(home: TrackPage()),
+      ),
+    );
+
+    await tester.pumpAndSettle();
+
+    final quickCheck = AppLocalizations('en').translate('quick_check');
+    await tester.tap(find.text(quickCheck));
+    await tester.pump();
+
+    final phoneError = AppLocalizations('en').translate('please_enter_phone_number');
+    final codeError = AppLocalizations('en').translate('please_enter_tracking_code');
+
+    expect(find.text(phoneError), findsOneWidget);
+    expect(find.text(codeError), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- add widget tests for TrackPage and EnhancedHistoryPage

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852622e256c832a97f8d6ba7fc606e0