### PR TITLE
Fix incomplete cargo detail parsing

### DIFF
--- a/lib/track_page.dart
+++ b/lib/track_page.dart
@@ -60,6 +60,14 @@ class _TrackPageState extends State<TrackPage> {
             value = value.substring(1).trim();
           }
           result[key] = value;
+        } else {
+          final text = li.text;
+          final idx = text.indexOf(':');
+          if (idx != -1) {
+            final key = text.substring(0, idx).trim();
+            final value = text.substring(idx + 1).trim();
+            result[key] = value;
+          }
         }
       }
       return result.isEmpty ? null : result;


### PR DESCRIPTION
## Summary
- improve HTML parser in `TrackPage` to fallback on plain text entries

## Testing
- `flutter test` *(fails: `flutter` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685269c763e0832aaf070af90c04822a