### PR TITLE
Fix header color for details page

### DIFF
--- a/lib/cargo_details_page.dart
+++ b/lib/cargo_details_page.dart
@@ -63,7 +63,9 @@ class CargoDetailsPage extends StatelessWidget {
             children: [
               Column(
                 children: [
-                  Container(height: 40, color: theme.scaffoldBackgroundColor),
+                  // Reserve space for the status badge while keeping the
+                  // header color consistent.
+                  Container(height: 40, color: primaryColor),
                   Container(
                     width: double.infinity,
                     padding: const EdgeInsets.symmetric(vertical: 24),


### PR DESCRIPTION
## Summary
- ensure the spacer at the top of the Cargo Details page uses the same background color as the header

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68528c9ec3c8832a81430628e588ef9b