### PR TITLE
Show dispatch status badges

### DIFF
--- a/lib/cargo_details_page.dart
+++ b/lib/cargo_details_page.dart
@@ -20,7 +20,7 @@ class CargoDetailsPage extends StatelessWidget {
     final Map<String, dynamic> cargoInfo = cargo['cargoInfo'];
     final bool hasDispatch = dispatchInfo != null;
 
-    final Color baseColor = isOut ? Colors.red : Colors.blue;
+    final Color baseColor = (isOut || hasDispatch) ? Colors.red : Colors.blue;
 
     Widget buildRow(String label, String value, {bool alt = false}) {
       final bgColor = isDark
@@ -115,7 +115,13 @@ class CargoDetailsPage extends StatelessWidget {
                     ],
                   ),
                   child: Text(
-                    loc.translate(isOut ? 'out' : 'store'),
+                    (() {
+                      final status =
+                          (dispatchInfo?['status'] ?? '').toString().trim();
+                      return status.isNotEmpty
+                          ? status
+                          : loc.translate(isOut ? 'out' : 'store');
+                    })(),
                     style: const TextStyle(
                       color: Colors.white,
                       fontWeight: FontWeight.bold,
@@ -136,7 +142,9 @@ class CargoDetailsPage extends StatelessWidget {
             ),
             buildRow(
               loc.translate('dispatch_status'),
-              dispatchInfo?['status'] ?? '-',
+              (dispatchInfo?['status'] ?? '').toString().trim().isNotEmpty
+                  ? (dispatchInfo?['status'] ?? '').toString().trim()
+                  : '-',
               alt: true,
             ),
             const Divider(thickness: 1),

--- a/lib/enhanced_history_page.dart
+++ b/lib/enhanced_history_page.dart
@@ -290,6 +290,10 @@ class _EnhancedHistoryPageState extends State<EnhancedHistoryPage> {
             itemBuilder: (context, index) {
               final isDispatched = historyItems[index]['dispatchInfo'] != null;
               final baseColor = isDispatched ? Colors.red : Colors.blue;
+              final badgeStatus =
+                  (historyItems[index]['dispatchInfo']?['status'] ?? '')
+                      .toString()
+                      .trim();
 
               return Card(
                 margin: const EdgeInsets.symmetric(vertical: 12.0, horizontal: 16.0),
@@ -447,7 +451,9 @@ class _EnhancedHistoryPageState extends State<EnhancedHistoryPage> {
                           ],
                         ),
                         child: Text(
-                          loc.translate(isDispatched ? 'out' : 'store'),
+                          badgeStatus.isNotEmpty
+                              ? badgeStatus
+                              : loc.translate(isDispatched ? 'out' : 'store'),
                           style: const TextStyle(
                             color: Colors.white,
                             fontWeight: FontWeight.bold,


### PR DESCRIPTION
## Summary
- highlight cargo details header when dispatch info exists
- display dispatch status text in cargo details badge
- display dispatch status text in history page badges

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68532be14f9c832abe5161626abdc57c