### PR TITLE
Restore pre-shipment JSON layouts

### DIFF
--- a/assets/data/shipments.json
+++ b/assets/data/shipments.json
@@ -1,0 +1,218 @@
+[
+  {
+    "id": "DL125244K",
+    "date": "24th-05-2025",
+    "status": "Out",
+    "route": "Dar es Salaam to Lubumbashi",
+    "dispatchInfo": {
+      "date": "Tuesday 27th-05-2025",
+      "status": "1 day left"
+    },
+    "cargoInfo": {
+      "registeredDateTime": "Saturday 24th-05-2025 / 03:26 PM",
+      "senderName": "HAMIS",
+      "receiverName": "ESTHER",
+      "senderPhone": "+255717434323",
+      "receiverPhone": "+243990328987",
+      "quantity": "1 (NGUO)",
+      "paymentOption": "To be Paid",
+      "totalPrice": "35,000.00"
+    }
+  },
+  {
+    "id": "DL129000K",
+    "date": "06th-06-2025",
+    "status": "Store",
+    "route": "Dar es Salaam to Lubumbashi",
+    "cargoInfo": {
+      "registeredDateTime": "Friday 06th-06-2025 / 06:42 PM",
+      "senderName": "RACHEL",
+      "receiverName": "BOBELLE",
+      "senderPhone": "+255692941104",
+      "receiverPhone": "+2437777",
+      "quantity": "1 (NGUO)",
+      "paymentOption": "To be Paid",
+      "totalPrice": "30,000.00"
+    }
+  },
+  {
+    "id": "DL125247C",
+    "date": "07th-06-2025",
+    "status": "Out",
+    "route": "Dar es Salaam to Lubumbashi",
+    "dispatchInfo": {
+      "date": "Wednesday 10th-06-2025",
+      "status": "Dispatching soon"
+    },
+    "cargoInfo": {
+      "registeredDateTime": "Sunday 07th-06-2025 / 10:00 AM",
+      "senderName": "JOHN",
+      "receiverName": "PAUL",
+      "senderPhone": "+255700000000",
+      "receiverPhone": "+243800000000",
+      "quantity": "2 (NGUO)",
+      "paymentOption": "Paid",
+      "totalPrice": "40,000.00"
+    }
+  },
+  {
+    "id": "DL129001A",
+    "date": "08th-06-2025",
+    "status": "Store",
+    "route": "Dar es Salaam to Lubumbashi",
+    "cargoInfo": {
+      "registeredDateTime": "Monday 08th-06-2025 / 09:15 AM",
+      "senderName": "ANNA",
+      "receiverName": "GRACE",
+      "senderPhone": "+255701234567",
+      "receiverPhone": "+243811111111",
+      "quantity": "3 (BOXES)",
+      "paymentOption": "To be Paid",
+      "totalPrice": "50,000.00"
+    }
+  },
+  {
+    "id": "DL125248D",
+    "date": "09th-06-2025",
+    "status": "Out",
+    "route": "Dar es Salaam to Lubumbashi",
+    "dispatchInfo": {
+      "date": "Thursday 12th-06-2025",
+      "status": "On schedule"
+    },
+    "cargoInfo": {
+      "registeredDateTime": "Tuesday 09th-06-2025 / 11:30 AM",
+      "senderName": "MARIA",
+      "receiverName": "PETER",
+      "senderPhone": "+255702222222",
+      "receiverPhone": "+243822222222",
+      "quantity": "1 (SUITCASE)",
+      "paymentOption": "Paid",
+      "totalPrice": "32,000.00"
+    }
+  },
+  {
+    "id": "DL129002B",
+    "date": "10th-06-2025",
+    "status": "Store",
+    "route": "Dar es Salaam to Lubumbashi",
+    "cargoInfo": {
+      "registeredDateTime": "Wednesday 10th-06-2025 / 02:20 PM",
+      "senderName": "CHRIS",
+      "receiverName": "LINDA",
+      "senderPhone": "+255703333333",
+      "receiverPhone": "+243833333333",
+      "quantity": "2 (BAGS)",
+      "paymentOption": "To be Paid",
+      "totalPrice": "28,000.00"
+    }
+  },
+  {
+    "id": "DL125249E",
+    "date": "11th-06-2025",
+    "status": "Out",
+    "route": "Dar es Salaam to Lubumbashi",
+    "dispatchInfo": {
+      "date": "Friday 13th-06-2025",
+      "status": "Ready to dispatch"
+    },
+    "cargoInfo": {
+      "registeredDateTime": "Thursday 11th-06-2025 / 03:45 PM",
+      "senderName": "VICTOR",
+      "receiverName": "TINA",
+      "senderPhone": "+255704444444",
+      "receiverPhone": "+243844444444",
+      "quantity": "1 (PARCEL)",
+      "paymentOption": "Paid",
+      "totalPrice": "27,000.00"
+    }
+  },
+  {
+    "id": "DL129003C",
+    "date": "12th-06-2025",
+    "status": "Store",
+    "route": "Dar es Salaam to Lubumbashi",
+    "cargoInfo": {
+      "registeredDateTime": "Friday 12th-06-2025 / 04:55 PM",
+      "senderName": "LUCY",
+      "receiverName": "HENRY",
+      "senderPhone": "+255705555555",
+      "receiverPhone": "+243855555555",
+      "quantity": "4 (BOXES)",
+      "paymentOption": "To be Paid",
+      "totalPrice": "60,000.00"
+    }
+  },
+  {
+    "id": "DL125250F",
+    "date": "13th-06-2025",
+    "status": "Out",
+    "route": "Dar es Salaam to Lubumbashi",
+    "dispatchInfo": {
+      "date": "Monday 15th-06-2025",
+      "status": "Delayed"
+    },
+    "cargoInfo": {
+      "registeredDateTime": "Saturday 13th-06-2025 / 08:10 AM",
+      "senderName": "DAVID",
+      "receiverName": "SARAH",
+      "senderPhone": "+255706666666",
+      "receiverPhone": "+243866666666",
+      "quantity": "3 (CRATES)",
+      "paymentOption": "Paid",
+      "totalPrice": "55,000.00"
+    }
+  },
+  {
+    "id": "DL129004D",
+    "date": "14th-06-2025",
+    "status": "Store",
+    "route": "Dar es Salaam to Lubumbashi",
+    "cargoInfo": {
+      "registeredDateTime": "Sunday 14th-06-2025 / 12:00 PM",
+      "senderName": "KEVIN",
+      "receiverName": "NANCY",
+      "senderPhone": "+255707777777",
+      "receiverPhone": "+243877777777",
+      "quantity": "1 (PACKAGE)",
+      "paymentOption": "To be Paid",
+      "totalPrice": "25,000.00"
+    }
+  },
+  {
+    "id": "DL125251G",
+    "date": "15th-06-2025",
+    "status": "Out",
+    "route": "Dar es Salaam to Lubumbashi",
+    "dispatchInfo": {
+      "date": "Tuesday 16th-06-2025",
+      "status": "In transit"
+    },
+    "cargoInfo": {
+      "registeredDateTime": "Monday 15th-06-2025 / 01:35 PM",
+      "senderName": "ERIC",
+      "receiverName": "ZARA",
+      "senderPhone": "+255708888888",
+      "receiverPhone": "+243888888888",
+      "quantity": "2 (BOXES)",
+      "paymentOption": "Paid",
+      "totalPrice": "42,000.00"
+    }
+  },
+  {
+    "id": "DL129005E",
+    "date": "16th-06-2025",
+    "status": "Store",
+    "route": "Dar es Salaam to Lubumbashi",
+    "cargoInfo": {
+      "registeredDateTime": "Tuesday 16th-06-2025 / 05:45 PM",
+      "senderName": "FIONA",
+      "receiverName": "GREG",
+      "senderPhone": "+255709999999",
+      "receiverPhone": "+243899999999",
+      "quantity": "1 (BAG)",
+      "paymentOption": "To be Paid",
+      "totalPrice": "26,000.00"
+    }
+  }
+]

--- a/lib/cargo_details_page.dart
+++ b/lib/cargo_details_page.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+
 import 'localization.dart';
 import 'providers/language_provider.dart';
 
@@ -8,216 +9,134 @@ class CargoDetailsPage extends StatelessWidget {
 
   const CargoDetailsPage({super.key, required this.cargo});
 
-  Widget _buildInfoStripe(
-    BuildContext context,
-    String label,
-    String value,
-    bool isDark, {
-    bool alt = false,
-  }) {
-    final theme = Theme.of(context);
-    final bgColor = isDark
-        ? (alt ? const Color(0xFF2A2A2A) : const Color(0xFF1E1E1E))
-        : (alt ? const Color(0xFFF5F5F5) : const Color(0xFFFFFFFF));
-    return Container(
-      color: bgColor,
-      padding: const EdgeInsets.symmetric(vertical: 12, horizontal: 16),
-      width: double.infinity,
-      child: Row(
-        mainAxisAlignment: MainAxisAlignment.spaceBetween,
-        children: [
-          Text(label, style: theme.textTheme.bodyMedium?.copyWith(fontWeight: FontWeight.bold)),
-          Flexible(
-            child: Text(
-              value,
-              style: theme.textTheme.bodyMedium,
-              textAlign: TextAlign.right,
-            ),
-          ),
-        ],
-      ),
-    );
-  }
-
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final isDark = theme.brightness == Brightness.dark;
-    final loc =
-        AppLocalizations(Provider.of<LanguageProvider>(context).languageCode);
-
+    final bool isOut = cargo['status'] == 'Out';
+    final Color baseColor = isOut ? Colors.red : Colors.blue;
+    final bool isDark = theme.brightness == Brightness.dark;
+    final loc = AppLocalizations(Provider.of<LanguageProvider>(context).languageCode);
     final Map<String, dynamic>? dispatchInfo = cargo['dispatchInfo'];
     final Map<String, dynamic> cargoInfo = cargo['cargoInfo'];
-    final bool isDispatched = dispatchInfo != null;
 
-    final Color baseColor = isDispatched ? Colors.red : Colors.blue;
+    /// Convenience widget used to present a label/value pair.
+    Widget buildRow(String label, String value, {bool alt = false}) {
+      final bgColor = isDark
+          ? (alt ? const Color(0xFF2A2A2A) : const Color(0xFF1E1E1E))
+          : (alt ? const Color(0xFFF5F5F5) : const Color(0xFFFFFFFF));
+      return Container(
+        color: bgColor,
+        padding: const EdgeInsets.symmetric(vertical: 12, horizontal: 16),
+        width: double.infinity,
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            Text(label,
+                style: theme.textTheme.bodyMedium
+                    ?.copyWith(fontWeight: FontWeight.bold)),
+            Flexible(
+              child: Text(
+                value,
+                textAlign: TextAlign.right,
+                style: theme.textTheme.bodyMedium,
+              ),
+            ),
+          ],
+        ),
+      );
+    }
 
     return Scaffold(
       appBar: AppBar(
         title: Text(loc.translate('cargo_details')),
+        backgroundColor: baseColor,
+        iconTheme: const IconThemeData(color: Colors.white),
       ),
-      backgroundColor: theme.scaffoldBackgroundColor,
       body: ListView(
         children: [
-          Card(
-            margin: const EdgeInsets.all(16),
-            color: theme.cardColor,
-            elevation: 4,
-            shape:
-                RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
-            child: Stack(
-              children: [
-                Column(
-                  children: [
-                    Container(
-                      height: 40,
-                      decoration: BoxDecoration(
-                        color: theme.scaffoldBackgroundColor,
-                        borderRadius: const BorderRadius.only(
-                          topLeft: Radius.circular(12),
-                          topRight: Radius.circular(12),
-                        ),
-                      ),
-                    ),
-                    Container(
-                      width: double.infinity,
-                      padding: const EdgeInsets.all(20),
-                      color: baseColor,
-                      child: Column(
-                        crossAxisAlignment: CrossAxisAlignment.center,
-                        children: [
-                          Text(
-                            cargo['date'] ?? '',
-                            textAlign: TextAlign.center,
-                            style: theme.textTheme.bodyLarge
-                                ?.copyWith(color: Colors.white),
-                          ),
-                          const SizedBox(height: 8),
-                          Text(
-                            cargo['id'] ?? '',
-                            textAlign: TextAlign.center,
-                            style: theme.textTheme.titleLarge?.copyWith(
-                                color: Colors.white,
-                                fontWeight: FontWeight.bold),
-                          ),
-                          const SizedBox(height: 8),
-                          Text(
-                            cargo['route'] ?? '',
-                            textAlign: TextAlign.center,
-                            style: theme.textTheme.bodyLarge
-                                ?.copyWith(color: Colors.white),
-                          ),
-                        ],
-                      ),
-                    ),
-                    if (isDispatched)
-                      ExpansionTile(
-                        title: Text(
-                          loc.translate('dispatch_info'),
-                          style: theme.textTheme.titleMedium?.copyWith(
-                            fontWeight: FontWeight.bold,
-                            color: isDark ? Colors.white : Colors.black,
-                          ),
-                        ),
-                        children: [
-                          _buildInfoStripe(
-                              context,
-                              '${loc.translate('dispatch_date')}:',
-                              dispatchInfo?['date'] ?? '',
-                              isDark),
-                          _buildInfoStripe(
-                              context,
-                              '${loc.translate('dispatch_status')}:',
-                              (dispatchInfo?['status'] ?? '').toString().trim(),
-                              isDark,
-                              alt: true),
-                        ],
-                      ),
-                    ExpansionTile(
-                      title: Text(
-                        loc.translate('cargo_info'),
-                        style: theme.textTheme.titleMedium?.copyWith(
-                          fontWeight: FontWeight.bold,
-                          color: isDark ? Colors.white : Colors.black,
-                        ),
-                      ),
+          Stack(
+            children: [
+              Column(
+                children: [
+                  Container(
+                    height: 40,
+                    color: theme.scaffoldBackgroundColor,
+                  ),
+                  Container(
+                    width: double.infinity,
+                    padding: const EdgeInsets.all(24),
+                    color: baseColor,
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.center,
                       children: [
-                        _buildInfoStripe(
-                            context,
-                            '${loc.translate('registered')}:',
-                            cargoInfo['registeredDateTime'] ?? '',
-                            isDark,
-                            alt: true),
-                        _buildInfoStripe(
-                            context,
-                            '${loc.translate('sender')}:',
-                            '${cargoInfo['senderName'] ?? ''} - ${cargoInfo['senderPhone'] ?? ''}',
-                            isDark),
-                        _buildInfoStripe(
-                            context,
-                            '${loc.translate('receiver')}:',
-                            '${cargoInfo['receiverName'] ?? ''} - ${cargoInfo['receiverPhone'] ?? ''}',
-                            isDark,
-                            alt: true),
-                        _buildInfoStripe(
-                            context,
-                            '${loc.translate('quantity')}:',
-                            cargoInfo['quantity'] ?? '',
-                            isDark),
-                        _buildInfoStripe(
-                            context,
-                            '${loc.translate('payment_option')}:',
-                            cargoInfo['paymentOption'] ?? '',
-                            isDark,
-                            alt: true),
-                        _buildInfoStripe(
-                            context,
-                            '${loc.translate('total_price')}:',
-                            cargoInfo['totalPrice'] ?? '',
-                            isDark,
-                            alt: true),
-                      ],
-                    ),
-                    const SizedBox(height: 16),
-                  ],
-                ),
-                Positioned(
-                  top: 0,
-                  left: 0,
-                  child: Container(
-                    margin: const EdgeInsets.all(12),
-                    padding: const EdgeInsets.all(22),
-                    decoration: BoxDecoration(
-                      shape: BoxShape.circle,
-                      color: baseColor,
-                      boxShadow: [
-                        BoxShadow(
-                          color: Colors.black.withOpacity(0.4),
-                          spreadRadius: 1,
-                          blurRadius: 6,
-                          offset: const Offset(0, 3),
+                        Text(
+                          cargo['date'],
+                          style: theme.textTheme.bodyLarge
+                              ?.copyWith(color: Colors.white),
+                        ),
+                        const SizedBox(height: 8),
+                        Text(
+                          cargo['id'],
+                          style: theme.textTheme.titleLarge?.copyWith(
+                              color: Colors.white, fontWeight: FontWeight.bold),
+                        ),
+                        const SizedBox(height: 8),
+                        Text(
+                          cargo['route'],
+                          style: theme.textTheme.bodyLarge
+                              ?.copyWith(color: Colors.white),
                         ),
                       ],
                     ),
-                    child: Text(
-                      (() {
-                        final status =
-                            (dispatchInfo?['status'] ?? '').toString().trim();
-                        return status.isNotEmpty
-                            ? status
-                            : loc.translate(isDispatched ? 'out' : 'store');
-                      })(),
-                      style: const TextStyle(
-                        color: Colors.white,
-                        fontWeight: FontWeight.bold,
-                        fontSize: 16,
+                  ),
+                ],
+              ),
+              Positioned(
+                top: 0,
+                left: 0,
+                child: Container(
+                  margin: const EdgeInsets.all(12),
+                  padding: const EdgeInsets.all(22),
+                  decoration: BoxDecoration(
+                    shape: BoxShape.circle,
+                    color: baseColor,
+                    boxShadow: [
+                      BoxShadow(
+                        color: Colors.black.withOpacity(0.4),
+                        spreadRadius: 1,
+                        blurRadius: 6,
+                        offset: const Offset(0, 3),
                       ),
+                    ],
+                  ),
+                  child: Text(
+                    loc.translate(isOut ? 'out' : 'store'),
+                    style: const TextStyle(
+                      color: Colors.white,
+                      fontWeight: FontWeight.bold,
+                      fontSize: 16,
                     ),
                   ),
                 ),
-              ],
-            ),
+              ),
+            ],
           ),
+          if (dispatchInfo != null) ...[
+            const SizedBox(height: 16),
+            buildRow(loc.translate('dispatch_date'), dispatchInfo['date']),
+            buildRow(loc.translate('dispatch_status'), dispatchInfo['status'], alt: true),
+          ],
+          const SizedBox(height: 16),
+          buildRow(loc.translate('registered'), cargoInfo['registeredDateTime']),
+          buildRow(loc.translate('sender'),
+              '${cargoInfo['senderName']} - ${cargoInfo['senderPhone']}',
+              alt: true),
+          buildRow(loc.translate('receiver'),
+              '${cargoInfo['receiverName']} - ${cargoInfo['receiverPhone']}'),
+          buildRow(loc.translate('quantity'), cargoInfo['quantity'], alt: true),
+          buildRow(loc.translate('payment_option'), cargoInfo['paymentOption']),
+          buildRow(loc.translate('total_price'), cargoInfo['totalPrice'], alt: true),
+          const SizedBox(height: 16),
         ],
       ),
     );

--- a/lib/enhanced_history_page.dart
+++ b/lib/enhanced_history_page.dart
@@ -1,16 +1,12 @@
+import 'dart:convert';
 import 'package:flutter/material.dart';
-import 'package:http/http.dart' as http;
-import 'package:html/parser.dart' as html_parser;
-import 'package:intl/intl.dart';
+import 'package:flutter/services.dart' show rootBundle;
 import 'package:provider/provider.dart';
-import 'package:shared_preferences/shared_preferences.dart';
 
 import 'localization.dart';
 import 'providers/language_provider.dart';
-import 'config.dart';
 
-/// Displays a list of previously tracked shipments fetched from the backend
-/// service using the receiver's phone number.
+/// Displays a list of previously tracked shipments from a bundled JSON file.
 
 class EnhancedHistoryPage extends StatefulWidget {
   const EnhancedHistoryPage({super.key});
@@ -20,280 +16,48 @@ class EnhancedHistoryPage extends StatefulWidget {
 }
 
 class _EnhancedHistoryPageState extends State<EnhancedHistoryPage> {
-  final _formKey = GlobalKey<FormState>();
-  final TextEditingController phoneController = TextEditingController();
-
-  Future<List<Map<String, dynamic>>?>? _historyFuture;
-  bool _isLoading = false;
+  late Future<List<dynamic>> _historyFuture;
 
   @override
   void initState() {
     super.initState();
-    _loadSavedNumber();
+    _historyFuture = _loadHistory();
   }
 
-  Future<void> _loadSavedNumber() async {
-    final prefs = await SharedPreferences.getInstance();
-    final saved = prefs.getString('savedPhoneNumber');
-    if (saved != null && saved.isNotEmpty) {
-      phoneController.text = saved;
-      setState(() {
-        _historyFuture = _fetchHistoryData(saved);
-      });
-    }
-  }
+  /// Reads shipment history information from the JSON asset.
 
-  Future<List<Map<String, dynamic>>?> _fetchHistoryData(String phone) async {
-    final url = Uri.parse('${AppConfig.apiBaseUrl}track/data.php');
-    try {
-      final response = await http.post(url, headers: {
-        'Content-Type': 'application/x-www-form-urlencoded'
-      }, body: {
-        'getData': '1',
-        'start': '0',
-        'limit': '10',
-        'phone_no': phone,
-        'state': "r_no='$phone'",
-      });
-      if (response.statusCode != 200) return null;
-      final cargos = _parseHistoryHtml(response.body);
-      cargos.sort((a, b) {
-        final d1 = _parseDate(a['date'] ?? '') ?? DateTime.fromMillisecondsSinceEpoch(0);
-        final d2 = _parseDate(b['date'] ?? '') ?? DateTime.fromMillisecondsSinceEpoch(0);
-        return d2.compareTo(d1);
-      });
-      return cargos;
-    } catch (_) {
-      return null;
-    }
-  }
-
-  List<Map<String, dynamic>> _parseHistoryHtml(String body) {
-    final document = html_parser.parse(body);
-    final sections = document.querySelectorAll('section');
-    final List<Map<String, dynamic>> cargos = [];
-    for (final section in sections) {
-      final info = <String, String>{};
-      final code = section.querySelector('h2')?.text.trim() ?? '';
-      if (code.isNotEmpty) info['Code'] = code;
-      final route = section.querySelector('p.btSubTitle')?.text.trim() ?? '';
-      if (route.isNotEmpty) info['Route'] = route;
-      for (final li in section.querySelectorAll('li')) {
-        final spans = li.querySelectorAll('span');
-        if (spans.length >= 2) {
-          var key = spans[0].text.trim();
-          var value = spans[1].text.replaceAll('\u00a0', ' ').trim();
-          if (value.startsWith('-')) value = value.substring(1).trim();
-          info[key] = value;
-        } else {
-          final text = li.text;
-          final idx = text.indexOf(':');
-          if (idx != -1) {
-            final key = text.substring(0, idx).trim();
-            final value = text.substring(idx + 1).trim();
-            info[key] = value;
-          }
-        }
-      }
-      cargos.add(_convertToCargo(info));
-    }
-    return cargos;
-  }
-
-  Map<String, dynamic> _convertToCargo(Map<String, String> info) {
-    String _first(List<String> keys) {
-      for (final k in keys) {
-        if (info.containsKey(k)) return info[k]!;
-      }
-      return '';
-    }
-
-    final dispatchDate = _first(['Dispatch date', 'Dispatch Date']);
-    final dispatchStatus = _first(['Dispatch status', 'Dispatch Status']);
-
-    final cargoInfo = {
-      'registeredDateTime':
-          _first(['Registered Date & Time', 'Registered date', 'Registered Date']),
-      'senderName': _first(["Sender's name", 'Sender name']),
-      'receiverName': _first(["Receiver's name", 'Receiver name']),
-      'senderPhone': _first(["Sender's phone number", 'Sender phone']),
-      'receiverPhone': _first(["Receiver's phone number", 'Receiver phone']),
-      'quantity': info['Quantity'] ?? '',
-      'paymentOption': _first(['Payment option', 'Payment Option']),
-      'totalPrice': _first(['Total price', 'Total Price']),
-    };
-
-    return {
-      'id': _first(['Code', 'ID', 'Ticket number', 'Ticket No', 'Ticket']),
-      'date': info['Date'] ?? info['Registered Date'] ?? '',
-      'route': info['Route'] ?? '',
-      if (dispatchDate.isNotEmpty || dispatchStatus.isNotEmpty)
-        'dispatchInfo': {'date': dispatchDate, 'status': dispatchStatus},
-      'cargoInfo': cargoInfo,
-    };
-  }
-
-  DateTime? _parseDate(String input) {
-    final patterns = [
-      'yyyy-MM-dd',
-      'dd/MM/yyyy',
-      'MM/dd/yyyy',
-      'dd-MM-yyyy',
-      'dd MMM yyyy',
-      'MMM dd, yyyy',
-    ];
-    for (final p in patterns) {
-      try {
-        return DateFormat(p).parseStrict(input);
-      } catch (_) {
-        continue;
-      }
-    }
-    return DateTime.tryParse(input);
+  Future<List<dynamic>> _loadHistory() async {
+    final data = await rootBundle.loadString('assets/data/shipments.json');
+    return json.decode(data) as List<dynamic>;
   }
 
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final isDark = theme.brightness == Brightness.dark;
-    final loc =
-        AppLocalizations(Provider.of<LanguageProvider>(context).languageCode);
-
-    if (_historyFuture == null) {
-      return Scaffold(
-        appBar: AppBar(
-          title: Text(loc.translate('tracking_history')),
-        ),
-        body: Stack(
-          children: [
-            Image.asset(
-              'assets/images/bus_background.png',
-              fit: BoxFit.cover,
-              height: double.infinity,
-              width: double.infinity,
-            ),
-            Container(color: Colors.black.withOpacity(0.5)),
-            Center(
-              child: SingleChildScrollView(
-                padding:
-                    const EdgeInsets.symmetric(horizontal: 16, vertical: 32),
-                child: Container(
-                  padding: const EdgeInsets.all(24),
-                  decoration: BoxDecoration(
-                    color: Colors.black.withOpacity(0.6),
-                    borderRadius: BorderRadius.circular(16),
-                  ),
-                  child: Form(
-                    key: _formKey,
-                    child: Column(
-                      mainAxisSize: MainAxisSize.min,
-                      crossAxisAlignment: CrossAxisAlignment.stretch,
-                      children: [
-                        Text(
-                          loc.translate('track_your_luggage'),
-                          style: theme.textTheme.headlineSmall?.copyWith(
-                              color: Colors.white,
-                              fontWeight: FontWeight.bold),
-                          textAlign: TextAlign.center,
-                        ),
-                        const SizedBox(height: 8),
-                        Text(
-                          loc.translate('enter_phone_and_code'),
-                          style: theme.textTheme.bodyMedium?.copyWith(
-                              color: Colors.white,
-                              fontWeight: FontWeight.w600),
-                          textAlign: TextAlign.center,
-                        ),
-                        const SizedBox(height: 24),
-                        Text(
-                          loc.translate('sender_receiver_number'),
-                          style: const TextStyle(
-                              color: Colors.white, fontWeight: FontWeight.w500),
-                        ),
-                        const SizedBox(height: 6),
-                        TextFormField(
-                          controller: phoneController,
-                          keyboardType: TextInputType.phone,
-                          style: const TextStyle(color: Colors.black),
-                          decoration: _inputDecoration('+243'),
-                          validator: (value) {
-                            if (value == null || value.isEmpty) {
-                              return loc.translate('please_enter_phone_number');
-                            }
-                            return null;
-                          },
-                        ),
-                        const SizedBox(height: 24),
-                        ElevatedButton(
-                          style: ElevatedButton.styleFrom(
-                            backgroundColor: Colors.red,
-                            padding: const EdgeInsets.symmetric(vertical: 16),
-                            shape: RoundedRectangleBorder(
-                              borderRadius: BorderRadius.circular(8),
-                            ),
-                          ),
-                          onPressed: () async {
-                            if (_formKey.currentState!.validate()) {
-                              setState(() {
-                                _isLoading = true;
-                              });
-                              final phone = phoneController.text.trim();
-                              _historyFuture = _fetchHistoryData(phone);
-                              final future = _historyFuture!;
-                              setState(() {});
-                              await future;
-                              setState(() {
-                                _isLoading = false;
-                              });
-                            }
-                          },
-                          child: Text(
-                            loc.translate('quick_check'),
-                            style: const TextStyle(
-                                color: Colors.white, fontWeight: FontWeight.bold),
-                          ),
-                        ),
-                      ],
-                    ),
-                  ),
-                ),
-              ),
-            ),
-            if (_isLoading)
-              Container(
-                color: Colors.black45,
-                child: const Center(child: CircularProgressIndicator()),
-              ),
-          ],
-        ),
-      );
-    }
+    final loc = AppLocalizations(Provider.of<LanguageProvider>(context).languageCode);
 
     return Scaffold(
       appBar: AppBar(
         title: Text(loc.translate('tracking_history')),
       ),
       backgroundColor: theme.scaffoldBackgroundColor,
-      body: FutureBuilder<List<Map<String, dynamic>>?>(
+      body: FutureBuilder<List<dynamic>>(
         future: _historyFuture,
         builder: (context, snapshot) {
           if (snapshot.connectionState != ConnectionState.done) {
             return const Center(child: CircularProgressIndicator());
           }
-          if (!snapshot.hasData || snapshot.data == null ||
-              (snapshot.data?.isEmpty ?? true)) {
-            return Center(child: Text(loc.translate('no_cargo_found')));
+          if (!snapshot.hasData) {
+            return const SizedBox.shrink();
           }
-          final historyItems = snapshot.data!;
+          final historyItems = snapshot.data!.cast<Map<String, dynamic>>();
           return ListView.builder(
             itemCount: historyItems.length,
             itemBuilder: (context, index) {
-              final isDispatched = historyItems[index]['dispatchInfo'] != null;
-              final baseColor = isDispatched ? Colors.red : Colors.blue;
-              final badgeStatus =
-                  (historyItems[index]['dispatchInfo']?['status'] ?? '')
-                      .toString()
-                      .trim();
+              final status = historyItems[index]['status'];
+              final isOut = status == 'Out';
+              final baseColor = isOut ? Colors.red : Colors.blue;
 
               return Card(
                 margin: const EdgeInsets.symmetric(vertical: 12.0, horizontal: 16.0),
@@ -346,27 +110,18 @@ class _EnhancedHistoryPageState extends State<EnhancedHistoryPage> {
                                   ],
                                 ),
                               ),
-                              if (isDispatched)
+                              if (isOut)
                                 ExpansionTile(
                                   title: Text(
                                     loc.translate('dispatch_info'),
-                                    style: theme.textTheme.titleMedium?.copyWith(
-                                      fontWeight: FontWeight.bold,
-                                      color: isDark ? Colors.white : Colors.black,
-                                    ),
+                                      style: theme.textTheme.titleMedium?.copyWith(
+                                        fontWeight: FontWeight.bold,
+                                        color: isDark ? Colors.white : Colors.black,
+                                      ),
                                   ),
                                   children: [
-                                    _buildInfoStripe(
-                                        context,
-                                        '${loc.translate('dispatch_date')}:',
-                                        historyItems[index]['dispatchInfo']?['date'] ?? '',
-                                        isDark),
-                                    _buildInfoStripe(
-                                        context,
-                                        '${loc.translate('dispatch_status')}:',
-                                        historyItems[index]['dispatchInfo']?['status'] ?? '',
-                                        isDark,
-                                        alt: true),
+                                    _buildInfoStripe(context, '${loc.translate('dispatch_date')}:', historyItems[index]['dispatchInfo']['date'], isDark),
+                                    _buildInfoStripe(context, '${loc.translate('status')}:', historyItems[index]['dispatchInfo']['status'], isDark, alt: true),
                                   ],
                                 ),
                               ExpansionTile(
@@ -378,53 +133,12 @@ class _EnhancedHistoryPageState extends State<EnhancedHistoryPage> {
                                   ),
                                 ),
                                 children: [
-                                  _buildInfoStripe(
-                                      context,
-                                      '${loc.translate('registered')}:',
-                                      historyItems[index]['cargoInfo']?['registeredDateTime'] ?? '',
-                                      isDark,
-                                      alt: true),
-                                  _buildInfoStripe(
-                                      context,
-                                      '${loc.translate('sender')}:',
-                                      '${historyItems[index]['cargoInfo']?['senderName'] ?? ''} - ${historyItems[index]['cargoInfo']?['senderPhone'] ?? ''}',
-                                      isDark),
-                                  _buildInfoStripe(
-                                      context,
-                                      '${loc.translate('receiver')}:',
-                                      '${historyItems[index]['cargoInfo']?['receiverName'] ?? ''} - ${historyItems[index]['cargoInfo']?['receiverPhone'] ?? ''}',
-                                      isDark,
-                                      alt: true),
-                                  _buildInfoStripe(
-                                      context,
-                                      '${loc.translate('quantity')}:',
-                                      historyItems[index]['cargoInfo']?['quantity'] ?? '',
-                                      isDark),
-                                  _buildInfoStripe(
-                                      context,
-                                      '${loc.translate('payment_option')}:',
-                                      historyItems[index]['cargoInfo']?['paymentOption'] ?? '',
-                                      isDark,
-                                      alt: true),
-                                  if ((historyItems[index]['cargoInfo']?['paidPrice'] ?? '').toString().isNotEmpty)
-                                    _buildInfoStripe(
-                                        context,
-                                        '${loc.translate('paid_price')}:',
-                                        historyItems[index]['cargoInfo']?['paidPrice'] ?? '',
-                                        isDark),
-                                  if ((historyItems[index]['cargoInfo']?['toBePaidPrice'] ?? '').toString().isNotEmpty)
-                                    _buildInfoStripe(
-                                        context,
-                                        '${loc.translate('to_be_paid_price')}:',
-                                        historyItems[index]['cargoInfo']?['toBePaidPrice'] ?? '',
-                                        isDark,
-                                        alt: (historyItems[index]['cargoInfo']?['paidPrice'] ?? '').toString().isNotEmpty ? true : false),
-                                  _buildInfoStripe(
-                                      context,
-                                      '${loc.translate('total_price')}:',
-                                      historyItems[index]['cargoInfo']?['totalPrice'] ?? '',
-                                      isDark,
-                                      alt: true),
+                                  _buildInfoStripe(context, '${loc.translate('registered')}:', historyItems[index]['cargoInfo']['registeredDateTime'], isDark),
+                                  _buildInfoStripe(context, '${loc.translate('sender')}:', '${historyItems[index]['cargoInfo']['senderName']} - ${historyItems[index]['cargoInfo']['senderPhone']}', isDark, alt: true),
+                                  _buildInfoStripe(context, '${loc.translate('receiver')}:', '${historyItems[index]['cargoInfo']['receiverName']} - ${historyItems[index]['cargoInfo']['receiverPhone']}', isDark),
+                                  _buildInfoStripe(context, '${loc.translate('quantity')}:', historyItems[index]['cargoInfo']['quantity'], isDark, alt: true),
+                                  _buildInfoStripe(context, '${loc.translate('payment_option')}:', historyItems[index]['cargoInfo']['paymentOption'], isDark),
+                                  _buildInfoStripe(context, '${loc.translate('total_price')}:', historyItems[index]['cargoInfo']['totalPrice'], isDark, alt: true),
                                 ],
                               ),
                             ],
@@ -451,9 +165,7 @@ class _EnhancedHistoryPageState extends State<EnhancedHistoryPage> {
                           ],
                         ),
                         child: Text(
-                          badgeStatus.isNotEmpty
-                              ? badgeStatus
-                              : loc.translate(isDispatched ? 'out' : 'store'),
+                          loc.translate(isOut ? 'out' : 'store'),
                           style: const TextStyle(
                             color: Colors.white,
                             fontWeight: FontWeight.bold,
@@ -495,23 +207,6 @@ class _EnhancedHistoryPageState extends State<EnhancedHistoryPage> {
             ),
           ),
         ],
-      ),
-    );
-  }
-
-  InputDecoration _inputDecoration(String hint) {
-    return InputDecoration(
-      hintText: hint,
-      hintStyle: const TextStyle(color: Colors.black45),
-      filled: true,
-      fillColor: Colors.white,
-      border: OutlineInputBorder(
-        borderRadius: BorderRadius.circular(10),
-        borderSide: BorderSide.none,
-      ),
-      focusedBorder: OutlineInputBorder(
-        borderRadius: BorderRadius.circular(10),
-        borderSide: const BorderSide(color: Colors.red),
       ),
     );
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -44,6 +44,7 @@ flutter:
     - assets/images/zambia_lusaka.png
     - assets/images/burundi_bujumbura.png
     - assets/images/app_icon.png
+    - assets/data/shipments.json
 
 flutter_launcher_icons:
   android: true


### PR DESCRIPTION
## Summary
- restore CargoDetails layout to the style used before `shipments.json` removal
- bring back the old History page implementation
- re-add `shipments.json` asset and reference it in pubspec

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853a28fef04832a8c15552ac6065c59